### PR TITLE
Fix link to EY notebook

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
 						We use Fairlearn to assess how different groups, defined in terms of their sex, are affected and how the observed disparities may be mitigated.
 					</p>
 					<div class="pt-2">
-						<a class="quickstart-btn mb-5 px-3 text-center" href="https://github.com/fairlearn/fairlearn/blob/main/notebooks/Binary%20Classification%20with%20the%20UCI%20Credit-card%20Default%20Dataset.ipynb">Jupyter Notebook</a>
+						<a class="quickstart-btn mb-5 px-3 text-center" href="https://fairlearn.org/main/auto_examples/plot_credit_loan_decisions.html#sphx-glr-auto-examples-plot-credit-loan-decisions-py">Jupyter Notebook</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Landing page updates don't currently work due to a little bug in the deploy scripts. The link is currently pointing nowhere (404) so this should fix it.